### PR TITLE
Add you.com support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ MCP SuperAssistant is a Chrome extension that integrates the Model Context Proto
 - [DeepSeek](https://chat.deepseek.com/)
 - [Kagi](https://kagi.com/assistant)
 - [T3 Chat](https://t3.chat/)
+- [You.com](https://you.com/)
 
 
 ## Demo Video

--- a/chrome-extension/manifest.ts
+++ b/chrome-extension/manifest.ts
@@ -42,6 +42,7 @@ const manifest = {
     '*://*.chat.deepseek.com/*',
     '*://*.kagi.com/*',
     '*://*.t3.chat/*',
+    '*://*.you.com/*',
   ],
 
   permissions: ['storage', 'clipboardWrite'],
@@ -123,6 +124,12 @@ const manifest = {
     // Specific content script for T3 Chat tool call parsing
     {
       matches: ['*://*.t3.chat/*'],
+      js: ['content/index.iife.js'],
+      run_at: 'document_idle',
+    },
+    // Specific content script for You.com tool call parsing
+    {
+      matches: ['*://*.you.com/*'],
       js: ['content/index.iife.js'],
       run_at: 'document_idle',
     },

--- a/pages/content/src/adapters/adaptercomponents/index.ts
+++ b/pages/content/src/adapters/adaptercomponents/index.ts
@@ -30,6 +30,9 @@ export { initKagiComponents } from './kagi';
 // Export T3 Chat components initializer
 export { initT3ChatComponents } from './t3chat';
 
+// Export You.com components initializer
+export { initYoucomComponents } from './you';
+
 // Note: Functions like insertToggleButtons, handleAutoInsert, handleAutoSubmit
 // are now part of the common framework and are not directly exported per adapter.
 // The initialization functions configure and start the common framework for each site.

--- a/pages/content/src/adapters/adaptercomponents/you.ts
+++ b/pages/content/src/adapters/adaptercomponents/you.ts
@@ -1,0 +1,31 @@
+import type { AdapterConfig, SimpleSiteAdapter } from './common';
+import { initializeAdapter } from './common';
+
+function findYouButtonInsertionPoint(): { container: Element; insertAfter: Element | null } | null {
+  const sendButton = document.querySelector('button[type="submit"]');
+  if (sendButton && sendButton.parentElement) {
+    return { container: sendButton.parentElement, insertAfter: sendButton };
+  }
+  return null;
+}
+
+function onMCPEnabled(adapter: SimpleSiteAdapter | null): void {
+  adapter?.sidebarManager?.show();
+}
+
+function onMCPDisabled(adapter: SimpleSiteAdapter | null): void {
+  adapter?.sidebarManager?.hide();
+}
+
+const youAdapterConfig: AdapterConfig = {
+  adapterName: 'YouCom',
+  storageKeyPrefix: 'mcp-youcom-state',
+  findButtonInsertionPoint: findYouButtonInsertionPoint,
+  getStorage: () => localStorage,
+  onMCPEnabled,
+  onMCPDisabled,
+};
+
+export function initYoucomComponents(): void {
+  initializeAdapter(youAdapterConfig);
+}

--- a/pages/content/src/adapters/index.ts
+++ b/pages/content/src/adapters/index.ts
@@ -17,6 +17,7 @@ import type { SiteAdapter } from '../utils/siteAdapter';
 import { DeepSeekAdapter } from './deepseekAdapter';
 import { KagiAdapter } from './kagiAdapter';
 import { T3ChatAdapter } from './t3chatAdapter';
+import { YouAdapter } from './youAdapter';
 
 // Define type for adapter constructor
 type AdapterConstructor = new () => SiteAdapter;
@@ -38,6 +39,7 @@ const adapterInfos: AdapterInfo[] = [
   { AdapterClass: DeepSeekAdapter, hostnames: ['chat.deepseek.com'] },
   { AdapterClass: KagiAdapter, hostnames: ['kagi.com'] },
   { AdapterClass: T3ChatAdapter, hostnames: ['t3.chat'] },
+  { AdapterClass: YouAdapter, hostnames: ['you.com'] },
 ];
 
 // Map of adapter instances that will be lazily initialized
@@ -221,3 +223,4 @@ export const openrouterAdapter = () => initializeAdapter(OpenRouterAdapter);
 export const deepseekAdapter = () => initializeAdapter(DeepSeekAdapter);
 export const kagiAdapter = () => initializeAdapter(KagiAdapter);
 export const t3chatAdapter = () => initializeAdapter(T3ChatAdapter);
+export const youAdapter = () => initializeAdapter(YouAdapter);

--- a/pages/content/src/adapters/youAdapter.ts
+++ b/pages/content/src/adapters/youAdapter.ts
@@ -1,0 +1,85 @@
+/**
+ * You.com Adapter
+ *
+ * Adapter implementation for you.com chat
+ */
+
+import { BaseAdapter } from './common';
+import { logMessage } from '../utils/helpers';
+import { insertToolResultToChatInput, attachFileToChatInput, submitChatInput } from '../components/websites/youcom';
+import { SidebarManager } from '../components/sidebar';
+import { initYoucomComponents } from './adaptercomponents/you';
+
+export class YouAdapter extends BaseAdapter {
+  name = 'YouCom';
+  hostname = ['you.com'];
+
+  private lastUrl: string = '';
+  private urlCheckInterval: number | null = null;
+
+  constructor() {
+    super();
+    this.sidebarManager = SidebarManager.getInstance('youcom');
+    logMessage('Created You.com sidebar manager instance');
+  }
+
+  protected initializeSidebarManager(): void {
+    this.sidebarManager.initialize();
+  }
+
+  protected initializeObserver(forceReset: boolean = false): void {
+    initYoucomComponents();
+    if (!this.urlCheckInterval) {
+      this.lastUrl = window.location.href;
+      this.urlCheckInterval = window.setInterval(() => {
+        const currentUrl = window.location.href;
+        if (currentUrl !== this.lastUrl) {
+          logMessage(`URL changed from ${this.lastUrl} to ${currentUrl}`);
+          this.lastUrl = currentUrl;
+          initYoucomComponents();
+        }
+      }, 1000);
+    }
+  }
+
+  cleanup(): void {
+    if (this.urlCheckInterval) {
+      window.clearInterval(this.urlCheckInterval);
+      this.urlCheckInterval = null;
+    }
+    super.cleanup();
+  }
+
+  insertTextIntoInput(text: string): void {
+    insertToolResultToChatInput(text);
+    logMessage(`Inserted text into You.com input: ${text.substring(0, 20)}...`);
+  }
+
+  triggerSubmission(): void {
+    submitChatInput()
+      .then(success => {
+        logMessage(`Triggered You.com form submission: ${success ? 'success' : 'failed'}`);
+      })
+      .catch(error => {
+        logMessage(`Error triggering You.com form submission: ${error}`);
+      });
+  }
+
+  supportsFileUpload(): boolean {
+    return true;
+  }
+
+  async attachFile(file: File): Promise<boolean> {
+    try {
+      return attachFileToChatInput(file);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logMessage(`Error attaching file to You.com input: ${message}`);
+      return false;
+    }
+  }
+
+  public forceFullScan(): void {
+    logMessage('Forcing full document scan for You.com');
+  }
+}

--- a/pages/content/src/components/sidebar/SidebarManager.tsx
+++ b/pages/content/src/components/sidebar/SidebarManager.tsx
@@ -26,6 +26,7 @@ export class SidebarManager extends BaseSidebarManager {
   private static deepseekInstance: SidebarManager | null = null;
   private static kagiInstance: SidebarManager | null = null;
   private static t3chatInstance: SidebarManager | null = null;
+  private static youcomInstance: SidebarManager | null = null;
   private lastToolOutputsHash: string = '';
   private lastMcpToolsHash: string = '';
   private isFirstLoad: boolean = true;
@@ -100,6 +101,11 @@ export class SidebarManager extends BaseSidebarManager {
           SidebarManager.t3chatInstance = new SidebarManager(siteType);
         }
         return SidebarManager.t3chatInstance;
+      case 'youcom':
+        if (!SidebarManager.youcomInstance) {
+          SidebarManager.youcomInstance = new SidebarManager(siteType);
+        }
+        return SidebarManager.youcomInstance;
       default:
         // For any unexpected site type, create and return a new instance
         logMessage(`Creating new SidebarManager for unknown site type: ${siteType}`);

--- a/pages/content/src/components/sidebar/base/BaseSidebarManager.tsx
+++ b/pages/content/src/components/sidebar/base/BaseSidebarManager.tsx
@@ -22,7 +22,8 @@ export type SiteType =
   | 'openrouter'
   | 'deepseek'
   | 'kagi'
-  | 't3chat';
+  | 't3chat'
+  | 'youcom';
 
 /**
  * BaseSidebarManager is a base class for creating sidebar managers

--- a/pages/content/src/components/websites/youcom/chatInputHandler.ts
+++ b/pages/content/src/components/websites/youcom/chatInputHandler.ts
@@ -1,0 +1,104 @@
+import { logMessage } from '@src/utils/helpers';
+
+let lastFoundInputElement: HTMLElement | null = null;
+
+export const findChatInputElement = (): HTMLElement | null => {
+  const selectors = [
+    'textarea',
+    'div[contenteditable="true"]',
+    'input[type="text"]',
+    'input[placeholder]',
+    'textarea[placeholder]'
+  ];
+  for (const selector of selectors) {
+    const el = document.querySelector(selector);
+    if (el && (el as HTMLElement).offsetParent !== null) {
+      lastFoundInputElement = el as HTMLElement;
+      logMessage(`Found You.com input via selector: ${selector}`);
+      return el as HTMLElement;
+    }
+  }
+  if (lastFoundInputElement && document.body.contains(lastFoundInputElement)) {
+    return lastFoundInputElement;
+  }
+  logMessage('Could not find You.com input element');
+  return null;
+};
+
+export const insertTextToChatInput = (text: string): boolean => {
+  const input = findChatInputElement();
+  if (!input) return false;
+  try {
+    if ('value' in input) {
+      const el = input as HTMLInputElement | HTMLTextAreaElement;
+      const current = el.value;
+      el.value = current ? `${current}\n\n${text}` : text;
+      const evt = new InputEvent('input', { bubbles: true });
+      el.dispatchEvent(evt);
+      el.focus();
+      return true;
+    }
+    if (input.getAttribute('contenteditable') === 'true') {
+      input.focus();
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(input);
+      range.collapse(false);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      document.execCommand('insertText', false, (input.textContent ? '\n\n' : '') + text);
+      const evt = new InputEvent('input', { bubbles: true });
+      input.dispatchEvent(evt);
+      return true;
+    }
+    input.textContent = (input.textContent || '') + '\n\n' + text;
+    const evt = new InputEvent('input', { bubbles: true });
+    input.dispatchEvent(evt);
+    input.focus();
+    return true;
+  } catch (e) {
+    logMessage(`Error inserting text into You.com input: ${e}`);
+    return false;
+  }
+};
+
+export const insertToolResultToChatInput = (result: string): boolean => {
+  return insertTextToChatInput(result);
+};
+
+export const attachFileToChatInput = (file: File): boolean => {
+  const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+  if (!fileInput) return false;
+  try {
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    fileInput.files = dt.files;
+    fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const submitChatInput = async (): Promise<boolean> => {
+  const selectors = [
+    'button[type="submit"]',
+    'button[aria-label="Send"]',
+    'button.send-button',
+    'button[data-testid="send-button"]'
+  ];
+  let button: HTMLElement | null = null;
+  for (const sel of selectors) {
+    const el = document.querySelector(sel);
+    if (el && el instanceof HTMLElement) { button = el; break; }
+  }
+  if (button) {
+    button.click();
+    return true;
+  }
+  const input = findChatInputElement();
+  if (!input) return false;
+  const event = new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true, cancelable: true });
+  input.dispatchEvent(event);
+  return true;
+};

--- a/pages/content/src/components/websites/youcom/index.ts
+++ b/pages/content/src/components/websites/youcom/index.ts
@@ -1,0 +1,10 @@
+/**
+ * You.com Module
+ *
+ * This file exports all You.com related functionality
+ */
+
+import './chatInputHandler';
+
+export { SidebarManager } from '@src/components/sidebar';
+export * from './chatInputHandler';

--- a/pages/content/src/render_prescript/src/core/config.ts
+++ b/pages/content/src/render_prescript/src/core/config.ts
@@ -144,6 +144,14 @@ export const WEBSITE_CONFIGS: Array<{
       function_result_selector: ['div[aria-label="Your message"]'],
     },
   },
+  {
+    urlPattern: 'you.com',
+    config: {
+      targetSelectors: ['pre'],
+      streamingContainerSelectors: ['pre'],
+      function_result_selector: ['div'],
+    },
+  },
   // Add more website-specific configurations as needed
   // Example:
   // {


### PR DESCRIPTION
## Summary
- implement You.com site adapter and DOM handlers
- register You.com components
- extend sidebar manager for new site type
- update render config and extension manifest
- document support for You.com

## Testing
- `pnpm lint` *(fails: unsupported Node version)*
- `pnpm build:eslint` *(fails: unsupported Node version)*

------
https://chatgpt.com/codex/tasks/task_e_683fa7a94d7c832087359849eae16ac1